### PR TITLE
Tabs

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,5 +4,9 @@ browser_window = Window()
 
 browser_window.add_tab_to_notebook()
 
+browser_window.add_tab_to_notebook()
+
+browser_window.add_tab_to_notebook()
+
 browser_window.start_event_loop()
 

--- a/tab.py
+++ b/tab.py
@@ -11,7 +11,7 @@ from history import SessionHistory
 
 class Tab:
 
-    def __init__(self, notebook):
+    def __init__(self, tab_label):
         '''
         Intialises a tab, including a webview rendering engine,
         search bar, search button and back button
@@ -46,8 +46,8 @@ class Tab:
         self.rendering_box.set_hexpand(True)
         self.rendering_box.set_vexpand(True)
 
-        # Registers url_requested() as event handler for page load events
-        self.rendering_box.connect('load-changed', self.url_requested)
+        # Registers url_load_handler() as event handler for page load events
+        self.rendering_box.connect('load-changed', self.url_load_handler)
 
         # Puts webview object into the grid 
         self.tab_grid.attach_next_to(self.rendering_box, self.address_bar, Gtk.PositionType.BOTTOM, 100, 100)
@@ -55,8 +55,12 @@ class Tab:
         # Loads default search engine
         self.rendering_box.load_uri('https://www.google.com')
 
-        # Appends this tab to the passed notebook 
-        notebook.append_page(self.tab_grid)
+        self.tab_label = tab_label
+
+    
+    def get_container(self):
+        # Returns the gui container of the tab
+        return self.tab_grid
 
 
     def search(self, widget):
@@ -95,15 +99,43 @@ class Tab:
         if uri is not None:
             self.rendering_box.load_uri(uri)
 
-    
-    def url_requested(self, current_webview_object, load_event_type):
+
+    def add_uri_to_history(self, uri):
         '''
-        Function called when a new page is loaded. Adds the page to session history if
+        Function to add uri to tab history
+        '''
+
+        if self.session_history.curr_uri() != uri:
+            self.session_history.add_uri(uri)
+
+    
+    def update_address_bar(self, address):
+        self.address_bar.set_text(address)
+
+
+    def update_tab_title(self, title):
+        self.tab_label.set_label(title)
+
+    
+    def url_load_handler(self, current_webview_object, load_event_type):
+        '''
+        Function called when a page load event occurs. 
+        If a page has started loading, sets the address bar and tab title to url.
+        If page has finished loading, sets tab title to title of html page.
+        Adds the page to session history if load is committed, and
         it is not already at the top of the stack (to prevent issues with refresh).
         '''
 
-        if load_event_type == WebKit2.LoadEvent.COMMITTED:
-            uri = current_webview_object.get_uri()
-            if self.session_history.curr_uri() != uri:
-                self.session_history.add_uri(uri)
+        uri = current_webview_object.get_uri()
+
+        if load_event_type == WebKit2.LoadEvent.STARTED:
+            self.update_address_bar(uri)
+            self.update_tab_title(uri)
+
+        elif load_event_type == WebKit2.LoadEvent.COMMITTED:
+            self.add_uri_to_history(uri)
+
+        elif load_event_type == WebKit2.LoadEvent.FINISHED:
+            self.update_tab_title(current_webview_object.get_title())
+            
                 

--- a/window.py
+++ b/window.py
@@ -1,6 +1,9 @@
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Pango", "1.0")
+
 from gi.repository import Gtk
+from gi.repository import Pango
 
 from tab import Tab
 
@@ -17,13 +20,31 @@ class Window:
         self.browser_window_notebook = Gtk.Notebook()
         self.browser_window.add(self.browser_window_notebook)
 
-        self.tab_list = []       
-
 
     def add_tab_to_notebook(self):
+        '''
+        Creates a new tab object, and adds the tab as a page in the notebook
+        Sets the tab to be reorderable
+        Creates a label object for labelling a page, and passes it to 
+        tab
+        '''
 
-        new_tab = Tab(self.browser_window_notebook)
-        self.tab_list.append(new_tab)
+        # Creates a new laebl with text Loading
+        tab_label = Gtk.Label("Loading")
+
+        # Sets width of label to MAX_WIDTH chars, so that all pages have same width
+        tab_label.set_width_chars(20)
+
+        # Adds ellipses to the end of label if text is too long
+        tab_label.set_ellipsize(Pango.EllipsizeMode.END)
+
+        new_tab = Tab(tab_label)
+
+        self.browser_window_notebook.append_page(new_tab.get_container())
+
+        self.browser_window_notebook.set_tab_label(new_tab.get_container(), tab_label)
+
+        self.browser_window_notebook.set_tab_reorderable(new_tab.get_container(), True)
 
     
     def start_event_loop(self):

--- a/window.py
+++ b/window.py
@@ -20,6 +20,9 @@ class Window:
         self.browser_window_notebook = Gtk.Notebook()
         self.browser_window.add(self.browser_window_notebook)
 
+        # Allow scrolling if too many tabs
+        self.browser_window_notebook.set_scrollable(True)
+
 
     def add_tab_to_notebook(self):
         '''


### PR DESCRIPTION
Now html page title is displayed as title of gtk page. Tabs can be reordered. If there are too many tabs, scrolling is enabled.

Made some structural changes to window and tab modules. 

TODO: Page title width is hardcoded, should be done by reading variable from a config file or smthing